### PR TITLE
Updated gpg.conf to generate keys compatible with Keybase

### DIFF
--- a/gpg.conf
+++ b/gpg.conf
@@ -9,7 +9,7 @@ personal-digest-preferences SHA512 SHA384 SHA256
 # Use ZLIB, BZIP2, ZIP, or no compression
 personal-compress-preferences ZLIB BZIP2 ZIP Uncompressed
 # Default preferences for new keys
-default-preference-list SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed
+default-preference-list SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed ks-modify no-mdc
 # SHA512 as digest to sign keys
 cert-digest-algo SHA512
 # SHA512 as digest for symmetric ops


### PR DESCRIPTION
Updated gpg.conf to generate keys compatible with Keybase by adding the ks-modify and no-mdc default key preferences as documented here: https://github.com/keybase/keybase-issues/issues/4025