### PR TITLE
Enforce memory locking to avoid accidentally swapping GPG memory to disk

### DIFF
--- a/gpg.conf
+++ b/gpg.conf
@@ -34,6 +34,8 @@ with-fingerprint
 #with-key-origin
 # Cross-certify subkeys are present and valid
 require-cross-certification
+# Enforce memory locking to avoid accidentally swapping GPG memory to disk
+require-secmem
 # Disable caching of passphrase for symmetrical ops
 no-symkey-cache
 # Output ASCII instead of binary


### PR DESCRIPTION
Hey, please consider enforcing memory locking in GPG conf:
```
$ man gpg | grep -A 2 -- --require-secmem
       --require-secmem
       --no-require-secmem
              Refuse to run if GnuPG cannot get secure memory. Defaults to no (i.e. run, but give a warning).
```
https://github.com/gpg/gnupg/blob/f0bca16ad3bd2a164bc93d56870be1a094fe3b71/doc/faq.org#why-do-i-get-gpg-warning-using-insecure-memory